### PR TITLE
fix: navbar menu disappearing after window resize

### DIFF
--- a/public/js/navbar.js
+++ b/public/js/navbar.js
@@ -10,3 +10,14 @@ menuBtn.onclick = () => {
 
   count++
 }
+
+let previousWidth = document.body.clientWidth
+
+document.defaultView.addEventListener('resize', e => {
+  if (document.body.clientWidth >= 601) {
+    menu.style = 'display:flex;'
+  } else if (previousWidth >= 601) {
+    menu.style = 'display:none;'
+  }
+  previousWidth = document.body.clientWidth
+})


### PR DESCRIPTION
This fixes a minor bug where (in smaller windows) after the hamburger menu was clicked twice and the window was resized, the navbar menu would disappear