### PR TITLE
refactor: removed unnecessary blog classes

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -98,12 +98,8 @@
   gap: 20px 20px;
 }
 
-.odd-row.blog__posts-large {
+.blog__posts-large {
   grid-column: 1 / span 2;
-}
-
-.even-row.blog__posts-large {
-  grid-column: 2 / span 2;
 }
 
 .blog__posts div {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -42,17 +42,17 @@
                 <div>Recent Posts</div>
             </div>
             <div class="blog__posts">
-                <div class="blog__posts-large odd-row">
+                <div class="blog__posts-large">
                     <img src="/assets/temp-blog-post.png">
                     <h2>LOREM IPSUM DOLOR ></h2>
                     <p class="blog__posts__subtitle">November 1, 2022</p>
                 </div>
-                <div class="blog__posts-small odd-row">
+                <div class="blog__posts-small">
                     <img src="/assets/temp-blog-post.png">
                     <h2>TITLE TEXT 2: SUBTITLE</h2>
                     <p class="blog__posts__subtitle">November 1, 2022</p>
                 </div>
-                <div class="blog__posts-small even-row">
+                <div class="blog__posts-small">
                     <img src="/assets/temp-blog-post.png">
                     <h2>TITLE TEXT 2: SUBTITLE</h2>
                     <p class="blog__posts__subtitle">November 1, 2022</p>


### PR DESCRIPTION
Now that the blog section button will redirect to a blog page rather than extending the blog section on the landing page, the odd and even row classes are no longer needed. 