### PR TITLE
contact form responsiveness

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -513,4 +513,12 @@ textarea {
         /* self style */
         text-align: left;
     }
+    .contact__content {
+        grid-template-columns: 1fr;
+        grid-template-rows: 2fr 3fr;
+    }
+    .contact__content__text {
+        grid-row: 1;
+        text-align: center;
+    }
 }


### PR DESCRIPTION
**Done**: contact section form is responsive as described in issue #99. When device width is under 600px, the form becomes one column two rows, as the image shows.

I also took the liberty of giving the grid a slight gap between rows when under 600px of width so the submit button isn't almost overlapped with the text, and aligned the text to the left side, as opposed to the left alignment that it has when the grid has two columns.
Feel free to make changes to, or discard these smaller changes.

![image](https://user-images.githubusercontent.com/73081185/204154318-de2c2f6b-95f5-4f09-af07-b432cdbcfab6.png)
