### PR TITLE
renamed "SOURCE" button to "ABOUT"

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -75,7 +75,7 @@
                 of the OAuth2 protocol, SMTP mailers, and DNS servers. Written in
                 Go, Typescript (Next.js), and deployed on Google Kubernetes Engine.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/OpenWebServices';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/OpenWebServices';">ABOUT</button>
             </div>
             <div id="card2" class="card">
               <h2>Bytes of Love</h2>
@@ -85,7 +85,7 @@
                 of your favorite programming languages! Built in Python with
                 tool: Renpy.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/VisualNovel';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/VisualNovel';">ABOUT</button>
             </div>
             <div id="card3" class="card">
               <h2>JukeBox</h2>
@@ -95,7 +95,7 @@
                 for future use. Built in React and Typescript with frameworks:
                 MongoDB, Express.js, React.js, and Node.js.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/Jukebox-Frontend';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/Jukebox-Frontend';">ABOUT</button>
             </div>
             <div id="card4" class="card">
               <h2>Proximity Chat</h2>
@@ -105,7 +105,7 @@
                 TypeScript with frameworks/tools: React Native, Firebase,
                 Node.js, Express.js, Expo.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/OSC-Proximity-Chat-App';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/OSC-Proximity-Chat-App';">ABOUT</button>
             </div>
             <div id="card5" class="card">
               <h2>OSC Website</h2>
@@ -115,7 +115,7 @@
                 management system. Built in Javascript, HTML, CSS, with the
                 frameworks/tools: Node.js, Express.js, EJS.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/Club_Website_2';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/Club_Website_2';">ABOUT</button>
             </div>
             <div id="card6" class="card">
               <h2>SwampScheduler</h2>
@@ -125,7 +125,7 @@
                 RateMyProfessor and GatorEval scores. Built in Typescript
                 and Python, with the frameworks/tools: React, Tailwind.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/Schedule_Helper';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/Schedule_Helper';">ABOUT</button>
             </div>
             <div id="card7" class="card">
               <h2>Manim</h2>
@@ -135,7 +135,7 @@
                 computer science concepts. Built in Python, with the
                 frameworks/tools: Poetry, Manim.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/manim-data-structures';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/manim-data-structures';">ABOUT</button>
             </div>
             <div id="card8" class="card">
               <h2>API Group</h2>
@@ -144,7 +144,7 @@
                 knowledge about building and using them. Built in Python,
                 with FastAPI.
               </p>
-              <button onclick="location.href = 'https://github.com/ufosc/UF-API-GROUP';">SOURCE</button>
+              <button onclick="location.href = 'https://github.com/ufosc/UF-API-GROUP';">ABOUT</button>
             </div>
             <button class="portfolio__cards__scroll__btn-left">
               <img src="./assets/left-swipe-arrow.png" alt="left arrow" width="45" height="45">


### PR DESCRIPTION

This PR renamed the "source" buttons in [views/index.ejs] to "ABOUT". 


Befor :- 
![Screenshot 2024-02-06 at 16 05 11](https://github.com/ufosc/Club_Website_2/assets/84280396/ec89e598-7b3c-4e68-8bc4-f54225fc7f6c)


Changes :- 

https://github.com/ufosc/Club_Website_2/assets/84280396/8d42e13b-c503-461c-b93e-11e248831735


Fix #190